### PR TITLE
Corrected the casing of the lib require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/Bcrypt');
+module.exports = require('./lib/BCrypt');


### PR DESCRIPTION
In some unix-based systems, the casing of the require causes issues
(i.e. the `Bcrypt` module doesn't exist). This corrects that issue.
